### PR TITLE
feat: Added generateSharedSecret.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const signature = await signMessage(messageToSign, privateKey.hex);
 ### Derive shared secret
 
 Derive a shared secret between a private key and a public key.
-Two parties deriving a secret with their respective private key and the partners public key generates the same shared secret.
+Two parties deriving a secret with their respective private key and the partners public key generate the same shared secret.
 
 ```ts
 import { generateSharedSecret } from "ln-verifymessagejs";

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ const signature = await signMessage(messageToSign, privateKey.hex);
 ### Derive shared secret
 
 Derive a shared secret between a private key and a public key.
+Two parties deriving a secret with their respective private key and the partners public key generates the same shared secret.
 
 ```ts
 import { generateSharedSecret } from "ln-verifymessagejs";

--- a/README.md
+++ b/README.md
@@ -80,8 +80,22 @@ const signature = await signMessage(messageToSign, privateKey.hex);
     - `options.signatureFormat: "hex" | "zbase"` Output encoding. Default is `zbase`.
     - `options.prefix: string` Message prefix. Default is `Lightning Signed Message:`.
 
+### Derive shared secret
 
+Derive a shared secret between a private key and a public key.
 
+```ts
+import { generateSharedSecret } from "ln-verifymessagejs";
+
+const myKeys = utils.generateKeyPair(); // Generate a keypair or use your own key.
+const partnerNodeId = '0200000000a3eff613189ca6c4070c89206ad658e286751eca1f29262948247a5f';
+
+const secret = generateSharedSecret(myKeys.privateKey.hex, partnerNodeId)
+```
+
+- `privateKey: Uint8Array | string` Private key either as bytes array or hex string.
+- `nodePubkey: string` Node id of the partner node.
+- `derivationName?: string` Optional derivation name to create a unique secret. Double sha256(baseSecret + derivationName).
 
 
 ## Sign with a Lightning Network node

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",
-        "sha.js": "^2.4.11",
-        "sjcl": "^1.0.8"
+        "sha.js": "^2.4.11"
       },
       "devDependencies": {
         "@types/jest": "^26.0.24",
@@ -4654,14 +4653,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "node_modules/sjcl": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
-      "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8904,11 +8895,6 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
-    },
-    "sjcl": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
-      "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ=="
     },
     "slash": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "ln-verifymessagejs",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ln-verifymessagejs",
-      "version": "1.0.0-rc.0",
-      "license": "ISC",
+      "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",
+        "sha.js": "^2.4.11",
         "sjcl": "^1.0.8"
       },
       "devDependencies": {
@@ -2313,8 +2314,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-ci": {
       "version": "3.0.0",
@@ -4563,6 +4563,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4588,6 +4607,18 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
       }
     },
     "node_modules/shebang-command": {
@@ -7025,8 +7056,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-ci": {
       "version": "3.0.0",
@@ -8813,6 +8843,11 @@
         "glob": "^7.1.3"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8833,6 +8868,15 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ln-verifymessagejs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Signs/checks message signatures like core-lightning checkmessge or lnd signmessage.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@noble/secp256k1": "^1.7.1",
-    "sha.js": "^2.4.11",
-    "sjcl": "^1.0.8"
+    "sha.js": "^2.4.11"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@noble/secp256k1": "^1.7.1",
+    "sha.js": "^2.4.11",
     "sjcl": "^1.0.8"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {deriveNodeId, deriveNodeIdZbase, deriveNodeIdHex, verifyMessage} from './verify';
 export {signMessage} from './sign'
 export * as utils from './utils'
+export {generateSharedSecret as generateSharedSecret} from './shared_secret';
 
 /**
  * Algorithm according to https://twitter.com/rusty_twit/status/1182102005914800128

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export {deriveNodeId, deriveNodeIdZbase, deriveNodeIdHex, verifyMessage} from './verify';
 export {signMessage} from './sign'
 export * as utils from './utils'
-export {generateSharedSecret as generateSharedSecret} from './shared_secret';
+export {generateSharedSecret} from './shared_secret';
 
 /**
  * Algorithm according to https://twitter.com/rusty_twit/status/1182102005914800128

--- a/src/shared_secret.ts
+++ b/src/shared_secret.ts
@@ -1,0 +1,23 @@
+import { hexToBytes } from "./utils";
+import * as sjcl from "sjcl";
+import * as secp from "@noble/secp256k1";
+
+/**
+ * Generate a shared secret between the private key and the public key (nodeId).
+ * @param privateKey Private key as bytes array or hex string.
+ * @param nodeId Lightning Node ID aka. public key as string.
+ * @param derivation Name/password that the key should be
+ * @returns Uint8Array
+ */
+export function generateSharedSecret(privateKey: Uint8Array | string, nodeId: string, derivation?: string) {
+    if (typeof privateKey === 'string' || privateKey instanceof String) {
+        privateKey = hexToBytes(privateKey as string)
+    }
+
+    const publicKey = hexToBytes(nodeId);
+    const sharedSecret = secp.getSharedSecret(privateKey, publicKey, true);
+    if (derivation){
+
+    }
+    return sharedSecret
+}

--- a/src/shared_secret.ts
+++ b/src/shared_secret.ts
@@ -1,23 +1,29 @@
-import { hexToBytes } from "./utils";
-import * as sjcl from "sjcl";
+import { dsha526, hexToBytes, stringToBytes } from "./utils";
 import * as secp from "@noble/secp256k1";
 
 /**
  * Generate a shared secret between the private key and the public key (nodeId).
  * @param privateKey Private key as bytes array or hex string.
- * @param nodeId Lightning Node ID aka. public key as string.
- * @param derivation Name/password that the key should be
+ * @param nodePubkey Lightning Node ID aka. public key as string.
+ * @param derivationName Name/password to derive a unique secret. Double sha256(baseSecret + derivation).
  * @returns Uint8Array
  */
-export function generateSharedSecret(privateKey: Uint8Array | string, nodeId: string, derivation?: string) {
+export function generateSharedSecret(privateKey: Uint8Array | string, nodePubkey: string, derivationName?: string) {
     if (typeof privateKey === 'string' || privateKey instanceof String) {
         privateKey = hexToBytes(privateKey as string)
     }
 
-    const publicKey = hexToBytes(nodeId);
-    const sharedSecret = secp.getSharedSecret(privateKey, publicKey, true);
-    if (derivation){
+    const publicKey = hexToBytes(nodePubkey);
+    let baseSecret = secp.getSharedSecret(privateKey, publicKey, true);
 
+    let prehashed = baseSecret;
+    if (derivationName){
+        let bytes = stringToBytes(derivationName)
+        const mergedArray = new Uint8Array(prehashed.length + bytes.length);
+        mergedArray.set(prehashed);
+        mergedArray.set(bytes, prehashed.length);
+        prehashed = mergedArray;
     }
-    return sharedSecret
+
+    return dsha526(prehashed)
 }

--- a/src/shared_secret.ts
+++ b/src/shared_secret.ts
@@ -5,7 +5,7 @@ import * as secp from "@noble/secp256k1";
  * Generate a shared secret between the private key and the public key (nodeId).
  * @param privateKey Private key as bytes array or hex string.
  * @param nodePubkey Lightning Node ID aka. public key as string.
- * @param derivationName Name/password to derive a unique secret. Double sha256(baseSecret + derivation).
+ * @param derivationName Name/password to derive a unique secret. Double sha256(baseSecret + derivationName).
  * @returns Uint8Array
  */
 export function generateSharedSecret(privateKey: Uint8Array | string, nodePubkey: string, derivationName?: string) {
@@ -15,15 +15,14 @@ export function generateSharedSecret(privateKey: Uint8Array | string, nodePubkey
 
     const publicKey = hexToBytes(nodePubkey);
     let baseSecret = secp.getSharedSecret(privateKey, publicKey, true);
-
-    let prehashed = baseSecret;
-    if (derivationName){
-        let bytes = stringToBytes(derivationName)
-        const mergedArray = new Uint8Array(prehashed.length + bytes.length);
-        mergedArray.set(prehashed);
-        mergedArray.set(bytes, prehashed.length);
-        prehashed = mergedArray;
+    if (!derivationName) {
+        return baseSecret
     }
 
-    return dsha526(prehashed)
+    let bytes = stringToBytes(derivationName)
+    const mergedArray = new Uint8Array(baseSecret.length + bytes.length);
+    mergedArray.set(baseSecret);
+    mergedArray.set(bytes, baseSecret.length);
+
+    return dsha526(baseSecret)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import * as sjcl from "sjcl";
 import * as secp from "@noble/secp256k1";
+import * as shajs from "sha.js";
+
 
 export const defaultLightningSignPrefix = 'Lightning Signed Message:'
 
@@ -20,6 +22,10 @@ export function hexToBytes(hex: string): Uint8Array {
         hex.match(/.{1,2}/g).map((byte) => parseInt(byte, 16))
     );
     return array;
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+    return secp.utils.bytesToHex(bytes)
 }
 
 export function getMessageHash(message: string, prefix: string = defaultLightningSignPrefix) {
@@ -66,4 +72,15 @@ export function generateKeyPair(): IKeyPair {
             bytes: pubKey
         }
     }
+}
+
+/**
+ * Creates a double sha256
+ * @param value 
+ * @returns 
+ */
+export function dsha526(value: Uint8Array | Buffer) {
+    const hash1: Buffer = shajs('sha256').update(value).digest();
+    const hash2: Buffer = shajs('sha256').update(hash1).digest();
+    return new Uint8Array(hash2);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import * as sjcl from "sjcl";
 import * as secp from "@noble/secp256k1";
 import * as shajs from "sha.js";
 
@@ -28,12 +27,19 @@ export function bytesToHex(bytes: Uint8Array): string {
     return secp.utils.bytesToHex(bytes)
 }
 
+export function stringToBytes(val: string): Uint8Array { 
+    const result = []; 
+    for (let i = 0; i < val.length; i++) { 
+        result.push(val.charCodeAt(i)); 
+    } 
+    return new Uint8Array(result); 
+} 
+
 export function getMessageHash(message: string, prefix: string = defaultLightningSignPrefix) {
     const messageWithPrefix = prefix + message;
-    const dsha256 = sjcl.hash.sha256.hash(
-        sjcl.hash.sha256.hash(messageWithPrefix)
-    );
-    return sjcl.codec.hex.fromBits(dsha256);
+    const messageBytes = stringToBytes(messageWithPrefix);
+    const hash = dsha526(messageBytes);
+    return bytesToHex(hash)
 }
 
 export interface IKeyPair {

--- a/test/derive.spec.ts
+++ b/test/derive.spec.ts
@@ -1,6 +1,6 @@
 import { deriveNodeIdZbase, deriveNodeIdHex, deriveNodeId } from "../src";
 
-test("deriveNodeIdZbase", () => {
+test("deriveNodeIdZbase default", () => {
     const nodeId = '02ac77f9f7397a64861b573c9e8b8652ce2e67a05150fd166831e9fc167670dfd8';
     const zBase = 'rbwzq7bjg1iw4xthgt463a1d88w5k4zmum9z3xtfbnhc7r3qoizrn8edgwtp8m5m6xfms7pcyccjuggr934tkkjwzewsid44zqub4iux';
     const message = 'test';
@@ -8,7 +8,7 @@ test("deriveNodeIdZbase", () => {
     expect(extractedNodeId).toEqual(nodeId);
 });
 
-test("deriveNodeIdHex", () => {
+test("deriveNodeIdHex default", () => {
     const nodeId = '02ac77f9f7397a64861b573c9e8b8652ce2e67a05150fd166831e9fc167670dfd8';
     const hex = '206977742934ab4d3e3c3475ece24339e9b56aeb9aff7cbe2508b8ce932e856e411d033522d3af6bf3cabb75ac03189998c4fe75152934ba296a8f5abba61d566f';
     const message = 'test';

--- a/test/shared_secret.spec.ts
+++ b/test/shared_secret.spec.ts
@@ -24,6 +24,12 @@ test("secp example", async () => {
 });
 
 test("getSharedSecret default case", async () => {
+    const shouldSecret = new Uint8Array([
+        216, 249,   8,  21, 131, 130, 217,  98,
+        141, 252, 212, 103,  97, 178, 150,  89,
+        165, 180,  76, 128, 183, 139, 229, 149,
+         10,  78, 235,   2,  83, 209, 217,   0
+      ])
     const alicePub = secp.getPublicKey(alicePriv, true)
     const aliceNodeId = Buffer.from(alicePub).toString('hex')
     const bobPub = secp.getPublicKey(bobPriv, true)
@@ -32,9 +38,23 @@ test("getSharedSecret default case", async () => {
 
     const sharedSecretAlice = generateSharedSecret(alicePriv, bobNodeId);
     const sharedSecretBob = generateSharedSecret(bobPriv, aliceNodeId);
-    const secpRawShared = secp.getSharedSecret(alicePriv, bobPub, true);
     
     expect(sharedSecretAlice).toEqual(sharedSecretBob)
-    expect(sharedSecretAlice).toEqual(secpRawShared)
+    expect(sharedSecretAlice).toEqual(shouldSecret)
+});
+
+test("getSharedSecret derivation", async () => {
+    const alicePub = secp.getPublicKey(alicePriv, true)
+    const aliceNodeId = Buffer.from(alicePub).toString('hex')
+    const bobPub = secp.getPublicKey(bobPriv, true)
+    const bobNodeId = Buffer.from(bobPub).toString('hex')
+    const derivationName = "ufo"
+
+    const underivedSecret = generateSharedSecret(alicePriv, bobNodeId)
+    const sharedSecretAlice = generateSharedSecret(alicePriv, bobNodeId, derivationName);
+    const sharedSecretBob = generateSharedSecret(bobPriv, aliceNodeId, derivationName);
+    
+    expect(sharedSecretAlice).toEqual(sharedSecretBob)
+    expect(sharedSecretAlice).not.toEqual(underivedSecret)
 });
 

--- a/test/shared_secret.spec.ts
+++ b/test/shared_secret.spec.ts
@@ -1,0 +1,40 @@
+import * as secp from "@noble/secp256k1";
+import { generateSharedSecret } from "../src/shared_secret";
+
+const alicePriv = new Uint8Array([
+    250, 54, 42, 69, 214, 70, 77, 20,
+    135, 187, 147, 247, 39, 15, 200, 85,
+    169, 168, 221, 176, 136, 131, 104, 187,
+    23, 78, 134, 227, 48, 33, 122, 213
+]);
+const bobPriv = new Uint8Array([
+    155, 201, 129, 184, 127, 9, 133, 135,
+    117, 203, 79, 109, 70, 215, 20, 12,
+    224, 14, 7, 43, 123, 202, 54, 29,
+    132, 162, 186, 61, 243, 227, 39, 230
+]);
+
+test("secp example", async () => {
+    const alicePub = secp.getPublicKey(alicePriv, false)
+    const bobPub = secp.getPublicKey(bobPriv, false)
+
+    const sharedSecretAlice = secp.getSharedSecret(alicePriv, bobPub, true);
+    const sharedSecretBob = secp.getSharedSecret(bobPriv, alicePub, true);
+    expect(sharedSecretAlice).toEqual(sharedSecretBob)
+});
+
+test("getSharedSecret default case", async () => {
+    const alicePub = secp.getPublicKey(alicePriv, true)
+    const aliceNodeId = Buffer.from(alicePub).toString('hex')
+    const bobPub = secp.getPublicKey(bobPriv, true)
+    const bobNodeId = Buffer.from(bobPub).toString('hex')
+
+
+    const sharedSecretAlice = generateSharedSecret(alicePriv, bobNodeId);
+    const sharedSecretBob = generateSharedSecret(bobPriv, aliceNodeId);
+    const secpRawShared = secp.getSharedSecret(alicePriv, bobPub, true);
+    
+    expect(sharedSecretAlice).toEqual(sharedSecretBob)
+    expect(sharedSecretAlice).toEqual(secpRawShared)
+});
+

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,7 +1,6 @@
 import * as secp from "@noble/secp256k1";
 import {utils} from '../src'
 import { bytesToHex, dsha526, hexToBytes } from "../src/utils";
-import * as sjcl from "sjcl";
 
 
 test("Match key string with bytes", async () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,6 +1,7 @@
 import * as secp from "@noble/secp256k1";
 import {utils} from '../src'
-import { hexToBytes } from "../src/utils";
+import { bytesToHex, dsha526, hexToBytes } from "../src/utils";
+import * as sjcl from "sjcl";
 
 
 test("Match key string with bytes", async () => {
@@ -14,6 +15,15 @@ test("Match key string with bytes", async () => {
 });
 
 
-
+test("dsha256", async () => {
+    const input = new Uint8Array([
+        250, 54, 42, 69, 214, 70, 77, 20,
+        135, 187, 147, 247, 39, 15, 200, 85,
+        169, 168, 221, 176, 136, 131, 104, 187,
+        23, 78, 134, 227, 48, 33, 122, 213
+    ]);
+    const hash = dsha526(input)
+    expect(hash).toEqual(new Uint8Array([179, 34, 87, 183, 183, 156, 156, 56, 23, 65, 122, 250, 131, 252, 176, 48, 203, 212, 161, 7, 140, 69, 140, 99, 185, 22, 74, 197, 114, 194, 250, 132]));
+});
 
 


### PR DESCRIPTION
Derive a shared secret between a private key and a public key/nodeId.
Two parties deriving a secret with their private key and the partners public key generates the same shared secret.

```ts
import { generateSharedSecret } from "ln-verifymessagejs";

const myKeys = utils.generateKeyPair(); // Generate a keypair or use your own key.
const partnerNodeId = '0200000000a3eff613189ca6c4070c89206ad658e286751eca1f29262948247a5f';

const secret = generateSharedSecret(myKeys.privateKey.hex, partnerNodeId)
```

- `privateKey: Uint8Array | string` Private key either as bytes array or hex string.
- `nodePubkey: string` Node id of the partner node.
- `derivationName?: string` Optional derivation name to create a unique secret. Double sha256(baseSecret + derivationName).